### PR TITLE
PVT-135 - Re-added packet pacing to threaded video network implementation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -508,13 +508,13 @@ static void *capture_thread(void *arg)
 }
 
 static bool parse_bitrate(char *optarg, long long int *bitrate) {
-        map<const char *, long long int> bitrate_spec_map = {
+        map<std::string, long long int> bitrate_spec_map = {
                 { "auto", RATE_AUTO },
                 { "dynamic", RATE_DYNAMIC },
                 { "unlimited", RATE_UNLIMITED },
         };
 
-        if (auto it = bitrate_spec_map.find(optarg); it != bitrate_spec_map.end()) {
+        if (auto it = bitrate_spec_map.find(std::string(optarg)); it != bitrate_spec_map.end()) {
                 *bitrate = it->second;
                 return true;
         }

--- a/src/rtp/playout_buffer.hpp
+++ b/src/rtp/playout_buffer.hpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <optional>
 #include <list>
 #include <mutex>
 #include <limits>

--- a/src/transmit.cpp
+++ b/src/transmit.cpp
@@ -139,6 +139,7 @@ void audio_tx_send_channel_segments(struct tx* tx, struct rtp *rtp_session, cons
 
 static bool set_fec(struct tx *tx, const char *fec);
 static void fec_check_messages(struct tx *tx);
+uint32_t calculateFrameTarget(struct tx*, struct video_frame*);
 
 struct rate_limit_dyn {
         unsigned long avg_frame_size;   ///< moving average
@@ -1248,7 +1249,7 @@ void tx_send_packets(struct tx *tx, struct rtp *rtpSession, const std::vector<in
     // Get the timing from the beginning, so we can calculate if we're on target or not.
     std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
     // Keep track of the total time spent pacing
-    std::chrono::duration idleDuration = std::chrono::duration(std::chrono::nanoseconds(0));
+    std::chrono::duration idleDuration = std::chrono::nanoseconds(0);
 
     // Loop for each packet we are sending
     for(int packetIndex = startingPacket; packetIndex < startingPacket + packetAmount; packetIndex++) {
@@ -1309,7 +1310,7 @@ void tx_send_packets(struct tx *tx, struct rtp *rtpSession, const std::vector<in
         // performance against our expected performance. If we are ahead
         // we should wait until we're at our expected timing.
         if(packetPace) {
-            // Get the time sentTimePoint
+            // Get the time
             std::chrono::high_resolution_clock::time_point sentTimePoint = std::chrono::high_resolution_clock::now();
             // Calculate where we should be according to our target
             std::chrono::duration targetDuration = std::chrono::nanoseconds(packetDurationTarget) * (loopIndex + 1);

--- a/src/transmit.cpp
+++ b/src/transmit.cpp
@@ -139,7 +139,7 @@ void audio_tx_send_channel_segments(struct tx* tx, struct rtp *rtp_session, cons
 
 static bool set_fec(struct tx *tx, const char *fec);
 static void fec_check_messages(struct tx *tx);
-uint32_t calculateFrameTarget(struct tx*, struct video_frame*);
+uint64_t calculateFrameTarget(struct tx*, struct video_frame*);
 
 struct rate_limit_dyn {
         unsigned long avg_frame_size;   ///< moving average
@@ -848,7 +848,7 @@ __attribute__((unused)) static long get_packet_rate(struct tx *tx, struct video_
         return packet_rate;
 }
 
-uint32_t calculateFrameTarget(struct tx* tx, struct video_frame* frame) {
+uint64_t calculateFrameTarget(struct tx* tx, struct video_frame* frame) {
     // If we're not limiting the rate, then return 0.
     switch(tx->bitrate) {
         case RATE_UNLIMITED: {
@@ -856,10 +856,10 @@ uint32_t calculateFrameTarget(struct tx* tx, struct video_frame* frame) {
         }
         default: {
             // Calculate the number of nanoseconds required for this frame to play
-            auto frameDuration = static_cast<uint32_t>(NANOSECOND / frame->fps);
+            auto frameDuration = static_cast<uint64_t>(NANOSECOND / frame->fps);
             // The sending of packets occurs once for each tile, so the target timing for sending the "frame"
             // needs to be split per tile.
-            uint32_t frameTarget = (frameDuration / frame->tile_count);
+            uint64_t frameTarget = (frameDuration / frame->tile_count);
             // We cannot use the entire duration of the frame, as we need timing for other operations, but we
             // could use up to 66% of the duration of the frame (28ms for a 24fps frame).
             return (frameTarget / 3) * 2;

--- a/src/transmit.cpp
+++ b/src/transmit.cpp
@@ -1237,8 +1237,12 @@ void tx_send_packets(struct tx *tx, struct rtp *rtpSession, const std::vector<in
     if(tx->videoFrameTarget == 0) {
         packetPace = false;
     }
+
+    uint64_t packetDurationTarget = 0;
     // Calculate the timing for each packet - Nanoseconds
-    uint64_t packetDurationTarget = tx->videoFrameTarget / packetAmount;
+    if(packetAmount > 0) {
+        packetDurationTarget = tx->videoFrameTarget / packetAmount;
+    }
 
     // Set up the variables we will use to send the packets
     size_t pos = initialPos;

--- a/src/video_capture/testcard2.c
+++ b/src/video_capture/testcard2.c
@@ -240,19 +240,10 @@ static int vidcap_testcard2_init(struct vidcap_params *params, void **state)
         s->play_audio_frame = FALSE;
 
         platform_sem_init(&s->semaphore, 0, 0);
-        printf("Testcard capture set to %dx%d\n", s->desc.width, s->desc.height);
+        log_msg(LOG_LEVEL_INFO, MOD_NAME "capture set to %dx%d @%.2gp, codec %s, bpc %d, pattern: %s, audio %s\n",
+                s->desc.width, s->desc.height, s->desc.fps, get_codec_name(s->desc.color_spec),
+                get_bits_per_component(s->desc.color_spec), "bars", s->grab_audio ? "on" : "off");
 
-        if(vidcap_params_get_flags(params) & VIDCAP_FLAG_AUDIO_EMBEDDED) {
-                s->grab_audio = TRUE;
-                if(configure_audio(s) != 0) {
-                        s->grab_audio = FALSE;
-                        fprintf(stderr, "[testcard] Disabling audio output. "
-                                        "SDL-mixer missing, running on Mac or other problem.");
-                }
-        } else {
-                s->grab_audio = FALSE;
-        }
-        
         if(!s->grab_audio) {
                 s->audio_tone = NULL;
                 s->audio_silence = NULL;


### PR DESCRIPTION
Added packet pacing to the threaded network implementation:
- Mostly focused on getting an implementation that will evenly spread the flow of packets across a desired target.
- Added parameter for controlling the target window (25ms default)
