### PR TITLE
PVT-550-PVT-551--from-PVT-221-2 match format

### DIFF
--- a/src/video_capture/testcard2.c
+++ b/src/video_capture/testcard2.c
@@ -50,6 +50,7 @@
 #include "utils/macros.h"
 #include "utils/thread.h"
 #include "video.h"
+#include "video_codec.h"
 #include "video_capture.h"
 #include "testcard_common.h"
 #include "compat/platform_semaphore.h"
@@ -240,7 +241,9 @@ static int vidcap_testcard2_init(struct vidcap_params *params, void **state)
         s->play_audio_frame = FALSE;
 
         platform_sem_init(&s->semaphore, 0, 0);
-        printf("Testcard capture set to %dx%d\n", s->desc.width, s->desc.height);
+        log_msg(LOG_LEVEL_INFO, MOD_NAME "capture set to %dx%d @%.2gp, codec %s, bpc %d, pattern: %s, audio %s\n",
+                s->desc.width, s->desc.height, s->desc.fps, get_codec_name(s->desc.color_spec),
+                get_bits_per_component(s->desc.color_spec), "bars", s->grab_audio ? "on" : "off");
 
         if(vidcap_params_get_flags(params) & VIDCAP_FLAG_AUDIO_EMBEDDED) {
                 s->grab_audio = TRUE;


### PR DESCRIPTION
Add `testcard2` to output to match the format of `testcard` and to be parsed by our log collector.